### PR TITLE
Add scheduled background job for news analysis

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,5 +2,47 @@
 from fastapi import FastAPI
 from api.routes import router as prediction_router
 
+# Scheduler imports
+from apscheduler.schedulers.background import BackgroundScheduler
+import atexit
+import json
+import os
+
+from context.news_scraper import fetch_articles
+from model.gpt_predict import analyze_news_article
+
+
 app = FastAPI()
 app.include_router(prediction_router, prefix="/predict")
+
+
+def process_articles():
+    """Fetch recent articles and log model predictions."""
+    articles = fetch_articles()
+    predictions = []
+    for article in articles:
+        result = analyze_news_article(article["content"])
+        predictions.append({"title": article["title"], "prediction": result})
+
+    if not predictions:
+        return
+
+    log_file = "predictions_log.json"
+    if os.path.exists(log_file):
+        with open(log_file, "r") as f:
+            existing = json.load(f)
+    else:
+        existing = []
+
+    existing.extend(predictions)
+    with open(log_file, "w") as f:
+        json.dump(existing, f, indent=2)
+
+
+# Run the job every hour in the background
+scheduler = BackgroundScheduler()
+scheduler.add_job(process_articles, "interval", hours=1)
+scheduler.start()
+
+# Shutdown scheduler when exiting the app
+atexit.register(lambda: scheduler.shutdown())

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 
+fastapi
+APScheduler


### PR DESCRIPTION
## Summary
- schedule background job to fetch latest news, analyze with GPT and log predictions
- document APScheduler dependency

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688dbe4f19ac83288a95a1c2d162ee50