### PR TITLE
Add newspaper3k and lxml html_clean dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-
 fastapi
 APScheduler
+newspaper3k
+lxml[html_clean]


### PR DESCRIPTION
## Summary
- add newspaper3k and lxml[html_clean] to requirements
- remove stray newline in requirements list

## Testing
- `python -m pytest >/tmp/unit_test.log && tail -n 20 /tmp/unit_test.log`


------
https://chatgpt.com/codex/tasks/task_e_688dc214a97c83289cc910ab99f69741