### PR TITLE
feat: display gemini predictions in browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,5 +22,17 @@ Fetches the latest financial news and analyzes each article with Google's Gemini
 
 2. Configure a `.env` file with your `GOOGLE_API_KEY`.
 
-3. Run `main.py` to start the notifier.
+3. Start the FastAPI server with Uvicorn:
+
+   ```bash
+   uvicorn main:app --reload
+   ```
+
+   The background scheduler fetches articles every hour and logs Gemini's
+   predictions to `predictions_log.json`.
+
+4. Open [http://localhost:8000/](http://localhost:8000/) to see the stored
+   predictions in a simple HTML table.  Use the interactive API docs at
+   [http://localhost:8000/docs](http://localhost:8000/docs) to manually submit
+   articles to `/predict`.
 

--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 
 from fastapi import FastAPI
+from fastapi.responses import HTMLResponse
 from api.routes import router as prediction_router
 
 # Scheduler imports
@@ -14,6 +15,36 @@ from model.gpt_predict import analyze_news_article
 
 app = FastAPI()
 app.include_router(prediction_router, prefix="/predict")
+
+
+@app.get("/", response_class=HTMLResponse)
+def read_predictions():
+    """Display stored Gemini analysis predictions as an HTML table."""
+    log_file = "predictions_log.json"
+    if not os.path.exists(log_file):
+        return "<h1>No predictions available</h1>"
+
+    with open(log_file, "r") as f:
+        predictions = json.load(f)
+
+    rows = "".join(
+        f"<tr><td>{p['title']}</td><td>{p['prediction']}</td></tr>"
+        for p in predictions
+    )
+
+    html = f"""
+    <html>
+        <head><title>Gemini Analysis</title></head>
+        <body>
+            <h1>Gemini Analysis Predictions</h1>
+            <table border='1'>
+                <tr><th>Article</th><th>Prediction</th></tr>
+                {rows}
+            </table>
+        </body>
+    </html>
+    """
+    return HTMLResponse(content=html)
 
 
 def process_articles():


### PR DESCRIPTION
## Summary
- add root FastAPI endpoint that renders stored Gemini predictions as an HTML table
- document how to run the server and view predictions

## Testing
- `python -m py_compile main.py api/routes.py context/news_scraper.py model/gpt_predict.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688dc42b47c88328a40f8aa0015dc60b