### PR TITLE
Add start endpoint and return predictions

### DIFF
--- a/main.py
+++ b/main.py
@@ -47,6 +47,12 @@ def read_predictions():
     return HTMLResponse(content=html)
 
 
+@app.get("/start")
+def start_process():
+    """Manually trigger article processing and return predictions."""
+    return process_articles()
+
+
 def process_articles():
     """Fetch recent articles and log model predictions."""
     articles = fetch_articles()
@@ -56,7 +62,7 @@ def process_articles():
         predictions.append({"title": article["title"], "prediction": result})
 
     if not predictions:
-        return
+        return []
 
     log_file = "predictions_log.json"
     if os.path.exists(log_file):
@@ -68,6 +74,8 @@ def process_articles():
     existing.extend(predictions)
     with open(log_file, "w") as f:
         json.dump(existing, f, indent=2)
+
+    return predictions
 
 
 # Run the job every hour in the background


### PR DESCRIPTION
## Summary
- add `/start` endpoint to manually trigger article processing
- refactor `process_articles` to return prediction list instead of None

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688dc6ca985883289aa62e6f463a6b42