### PR TITLE
Make scheduler optional

### DIFF
--- a/main.py
+++ b/main.py
@@ -78,10 +78,12 @@ def process_articles():
     return predictions
 
 
-# Run the job every hour in the background
-scheduler = BackgroundScheduler()
-scheduler.add_job(process_articles, "interval", hours=1)
-scheduler.start()
+# Run the job every hour in the background (disabled by default).
+# To enable, set the environment variable ENABLE_SCHEDULER to a truthy value.
+if os.getenv("ENABLE_SCHEDULER"):
+    scheduler = BackgroundScheduler()
+    scheduler.add_job(process_articles, "interval", hours=1)
+    scheduler.start()
 
-# Shutdown scheduler when exiting the app
-atexit.register(lambda: scheduler.shutdown())
+    # Shutdown scheduler when exiting the app
+    atexit.register(lambda: scheduler.shutdown())


### PR DESCRIPTION
## Summary
- disable background scheduler by default and gate behind ENABLE_SCHEDULER env var in main.py

## Testing
- `pytest`
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_688dc7b312348328bf7e5b71ba3a2df0