### PR TITLE
feat: allow selecting RSS feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,20 @@ Fetches the latest financial news and analyzes each article with Google's Gemini
    [http://localhost:8000/docs](http://localhost:8000/docs) to manually submit
    articles to `/predict`.
 
+## Choosing the News Source
+
+By default the app pulls articles from the Economic Times stocks RSS feed. To
+use a different source, set the `RSS_FEED_URL` environment variable before
+starting the server or pass a feed URL to `fetch_articles` in your own code.
+
+```bash
+export RSS_FEED_URL="https://in.finance.yahoo.com/rss/topstories"  # Yahoo Finance
+uvicorn main:app --reload
+```
+
+Constants such as `ECONOMIC_TIMES_RSS` and `YAHOO_FINANCE_INDIA_RSS` are
+available in `context/news_scraper.py` for convenience.
+
 
 ## `/start` Endpoint
 

--- a/context/news_scraper.py
+++ b/context/news_scraper.py
@@ -1,18 +1,24 @@
+import os
+
 import feedparser
 from newspaper import Article
 
-# Default RSS feed for Indian financial news.
+# RSS feeds for Indian financial news sources.
 YAHOO_FINANCE_INDIA_RSS = "https://in.finance.yahoo.com/rss/topstories"
+ECONOMIC_TIMES_RSS = (
+    "https://economictimes.indiatimes.com/markets/stocks/rssfeeds/2146842.cms"
+)
 
 
-def fetch_articles(rss_url: str = YAHOO_FINANCE_INDIA_RSS):
+def fetch_articles(rss_url: str | None = None):
     """Fetch the latest financial news articles.
 
     Parameters
     ----------
     rss_url: str, optional
-        RSS feed URL pointing to an Indian financial news source. Defaults to
-        Yahoo Finance India's top stories feed.
+        RSS feed URL pointing to an Indian financial news source. If not
+        provided, the ``RSS_FEED_URL`` environment variable is used. If the
+        environment variable is unset, defaults to the Economic Times RSS feed.
 
     Returns
     -------
@@ -20,7 +26,8 @@ def fetch_articles(rss_url: str = YAHOO_FINANCE_INDIA_RSS):
         A list of dictionaries containing the article title and full text.
     """
 
-    feed = feedparser.parse(rss_url)
+    feed_url = rss_url or os.getenv("RSS_FEED_URL", ECONOMIC_TIMES_RSS)
+    feed = feedparser.parse(feed_url)
     news = []
     for entry in feed.entries[:5]:
         article = Article(entry.link)

--- a/main.py
+++ b/main.py
@@ -52,7 +52,8 @@ def start_process():
     """Run article processing and display step-by-step status as HTML."""
 
     # Step 1: Fetch articles
-    articles = fetch_articles()
+    rss_url = os.getenv("RSS_FEED_URL")
+    articles = fetch_articles(rss_url)
     titles_html = "".join(f"<li>{a['title']}</li>" for a in articles) or "<li>No articles found</li>"
 
     # Step 2: Analyze articles with Gemini
@@ -97,7 +98,8 @@ def start_process():
 
 def process_articles():
     """Fetch recent articles and log model predictions."""
-    articles = fetch_articles()
+    rss_url = os.getenv("RSS_FEED_URL")
+    articles = fetch_articles(rss_url)
     predictions = []
     for article in articles:
         result = analyze_news_article(article["content"])


### PR DESCRIPTION
## Summary
- add Economic Times RSS feed and env-based selection in `fetch_articles`
- allow main app to pass preferred RSS feed
- document overriding the default feed via `RSS_FEED_URL`

## Testing
- `pytest`
- `python -m py_compile context/news_scraper.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_688dcc5a82648328a8d4324693a059de