### PR TITLE
fix: update gemini models to supported versions

### DIFF
--- a/model/gpt_predict.py
+++ b/model/gpt_predict.py
@@ -15,8 +15,10 @@ ALLOW_FALLBACK = True
 
 # --- Setup Gemini ---
 genai.configure(api_key=os.getenv("GOOGLE_API_KEY"))
-pro_model = genai.GenerativeModel("gemini-pro")
-flash_model = genai.GenerativeModel("gemini-pro-vision")  # or "gemini-1.5-flash"
+PRO_MODEL_NAME = os.getenv("GENAI_PRO_MODEL", "gemini-1.5-pro")
+FALLBACK_MODEL_NAME = os.getenv("GENAI_FALLBACK_MODEL", "gemini-1.5-flash")
+pro_model = genai.GenerativeModel(PRO_MODEL_NAME)
+flash_model = genai.GenerativeModel(FALLBACK_MODEL_NAME)
 
 # --- Load or Init Request Log ---
 def load_request_log():


### PR DESCRIPTION
## Summary
- allow selecting Gemini models via environment variables
- default to supported `gemini-1.5-pro` and `gemini-1.5-flash`

## Testing
- `python -m py_compile model/gpt_predict.py`
- `pytest`
- `python - <<'PY'
import google.generativeai as genai
try:
    models = [m.name for m in genai.list_models()]
    print(models[:5])
except Exception as e:
    print('Error:', e)
PY`
- `python - <<'PY'
from model.gpt_predict import analyze_news_article
print(analyze_news_article("This is a test news article about Google."))
PY`

------
https://chatgpt.com/codex/tasks/task_e_688dcf1dd7648328be1cfd5037db5e0c