### PR TITLE
docs: add virtual environment setup steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,27 @@ Fetches the latest financial news and analyzes each article with Google's Gemini
 
 ## Setup
 
-1. Install the dependencies:
+1. Create a virtual environment:
+
+   ```bash
+   python3 -m venv venv
+   ```
+
+2. Activate the virtual environment:
+
+   - Linux/macOS:
+
+     ```bash
+     source venv/bin/activate
+     ```
+
+   - Windows:
+
+     ```bash
+     venv\Scripts\activate
+     ```
+
+3. Install the dependencies:
 
    ```bash
    pip install -r requirements.txt
@@ -20,9 +40,9 @@ Fetches the latest financial news and analyzes each article with Google's Gemini
    - newspaper3k
    - python-dotenv
 
-2. Configure a `.env` file with your `GOOGLE_API_KEY`.
+4. Configure a `.env` file with your `GOOGLE_API_KEY`.
 
-3. Start the FastAPI server with Uvicorn:
+5. Start the FastAPI server with Uvicorn:
 
    ```bash
    uvicorn main:app --reload
@@ -31,7 +51,7 @@ Fetches the latest financial news and analyzes each article with Google's Gemini
    The background scheduler fetches articles every hour and logs Gemini's
    predictions to `predictions_log.json`.
 
-4. Open [http://localhost:8000/](http://localhost:8000/) to see the stored
+6. Open [http://localhost:8000/](http://localhost:8000/) to see the stored
    predictions in a simple HTML table.  Use the interactive API docs at
    [http://localhost:8000/docs](http://localhost:8000/docs) to manually submit
    articles to `/predict`.


### PR DESCRIPTION
## Summary
- document creating and activating a Python virtual environment
- renumber setup steps so server startup follows new instructions

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e41511868832890434b6f04ab9db7