### PR TITLE
Switch to Hugging Face LLM backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Stock News GPT Notifier
 
-Fetches the latest financial news and analyzes each article with Google's Gemini model.
+Fetches the latest financial news and analyzes each article with a Hugging Face hosted model.
 
 ## Setup
 
@@ -35,12 +35,14 @@ Fetches the latest financial news and analyzes each article with Google's Gemini
    - APScheduler
    - fastapi
    - feedparser
-   - google-generativeai
+   - langchain
+   - langchain-community
+   - huggingface-hub
    - lxml[html_clean]
    - newspaper3k
    - python-dotenv
 
-4. Configure a `.env` file with your `GOOGLE_API_KEY`.
+4. Configure a `.env` file with your `HUGGINGFACEHUB_API_TOKEN`.
 
 5. Start the FastAPI server with Uvicorn:
 
@@ -48,7 +50,7 @@ Fetches the latest financial news and analyzes each article with Google's Gemini
    uvicorn main:app --reload
    ```
 
-   The background scheduler fetches articles every hour and logs Gemini's
+   The background scheduler fetches articles every hour and logs Hugging Face
    predictions to `predictions_log.json`.
 
 6. Open [http://localhost:8000/](http://localhost:8000/) to see the stored
@@ -76,7 +78,7 @@ available in `context/news_scraper.py` for convenience.
 Visiting `/start` triggers the article processing pipeline and displays three steps:
 
 1. Fetch articles.
-2. Run Gemini analysis on each article.
+2. Run Hugging Face analysis on each article.
 3. Save predictions to `predictions_log.json`.
 
 The page returns an HTML report showing the results of each step.

--- a/api/routes.py
+++ b/api/routes.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter, HTTPException
-from model.gpt_predict import analyze_news_article
+from model.hf_predict import analyze_news_article
 
 router = APIRouter()
 

--- a/main.py
+++ b/main.py
@@ -10,7 +10,7 @@ import json
 import os
 
 from context.news_scraper import fetch_articles
-from model.gpt_predict import analyze_news_article
+from model.hf_predict import analyze_news_article
 
 
 app = FastAPI()
@@ -19,7 +19,7 @@ app.include_router(prediction_router, prefix="/predict")
 
 @app.get("/", response_class=HTMLResponse)
 def read_predictions():
-    """Display stored Gemini analysis predictions as an HTML table."""
+    """Display stored Hugging Face analysis predictions as an HTML table."""
     log_file = "predictions_log.json"
     if not os.path.exists(log_file):
         return "<h1>No predictions available</h1>"
@@ -34,9 +34,9 @@ def read_predictions():
 
     html = f"""
     <html>
-        <head><title>Gemini Analysis</title></head>
+        <head><title>Hugging Face Analysis</title></head>
         <body>
-            <h1>Gemini Analysis Predictions</h1>
+            <h1>Hugging Face Analysis Predictions</h1>
             <table border='1'>
                 <tr><th>Article</th><th>Prediction</th></tr>
                 {rows}
@@ -56,7 +56,7 @@ def start_process():
     articles = fetch_articles(rss_url)
     titles_html = "".join(f"<li>{a['title']}</li>" for a in articles) or "<li>No articles found</li>"
 
-    # Step 2: Analyze articles with Gemini
+    # Step 2: Analyze articles with Hugging Face
     predictions = []
     analysis_items = []
     for article in articles:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,6 @@ newspaper3k
 lxml[html_clean]
 feedparser
 python-dotenv
-google-generativeai
+langchain
+langchain-community
+huggingface-hub


### PR DESCRIPTION
## Summary
- replace Gemini integration with LangChain `HuggingFaceHub` client and retain rate‑limit logging
- update FastAPI endpoints and UI text to refer to the Hugging Face backend
- document new dependencies and configuration for Hugging Face

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement langchain)*
- `pytest`
- `python - <<'PY' ...`

------
https://chatgpt.com/codex/tasks/task_e_688e512deaf08328b9b0a5ac804014e7