### PR TITLE
Switch to langchain-huggingface

### DIFF
--- a/model/hf_predict.py
+++ b/model/hf_predict.py
@@ -2,7 +2,7 @@ import os
 import time
 import json
 from dotenv import load_dotenv
-from langchain_community.llms import HuggingFaceHub
+from langchain_huggingface import HuggingFaceEndpoint
 
 load_dotenv()
 
@@ -87,11 +87,11 @@ def analyze_news_article(text: str) -> str:
     task = "text2text-generation" if "t5" in model_name.lower() else "text-generation"
 
     try:
-        llm = HuggingFaceHub(
+        llm = HuggingFaceEndpoint(
             repo_id=model_name,
             huggingfacehub_api_token=HF_API_TOKEN,
-            model_kwargs={"temperature": 0.3},
             task=task,
+            model_kwargs={"temperature": 0.3},
         )
         result = llm.invoke(prompt).strip()
     except Exception as e:

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ lxml[html_clean]
 feedparser
 python-dotenv
 langchain
-langchain-community
+langchain-huggingface
 huggingface-hub


### PR DESCRIPTION
## Summary
- use `langchain-huggingface` for Hugging Face integration
- update dependencies and swap HuggingFaceHub for HuggingFaceEndpoint

## Testing
- `python -m pytest`
- `python -m py_compile model/hf_predict.py`


------
https://chatgpt.com/codex/tasks/task_e_688e5a42700c8328a35b45b826aa53b4