### PR TITLE
fix: pass temperature directly to HF endpoint

### DIFF
--- a/model/hf_predict.py
+++ b/model/hf_predict.py
@@ -91,7 +91,7 @@ def analyze_news_article(text: str) -> str:
             repo_id=model_name,
             huggingfacehub_api_token=HF_API_TOKEN,
             task=task,
-            model_kwargs={"temperature": 0.3},
+            temperature=0.3,
         )
         result = llm.invoke(prompt).strip()
     except Exception as e:


### PR DESCRIPTION
## Summary
- pass temperature directly to HuggingFaceEndpoint instead of through model_kwargs

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688e5d8988608328a7e9136ab3c430a4