### PR TITLE
Add torch dependency to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ python-dotenv
 langchain
 transformers
 huggingface-hub
+torch>=2.0


### PR DESCRIPTION
## Summary
- add torch>=2.0 to requirements for Hugging Face pipeline

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement torch>=2.0)*
- `pip install --index-url https://download.pytorch.org/whl/cpu torch>=2.0` *(fails: Could not find a version that satisfies the requirement torch)*
- `pytest`
- `python - <<'PY' ...` *(fails: ❌ Hugging Face API error due to missing framework and proxy restrictions)*


------
https://chatgpt.com/codex/tasks/task_e_688e63ceef108328a76a400b6b528865