### PR TITLE
Switch to FinBERT classification with trade signals

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,10 +82,8 @@ available in `context/news_scraper.py` for convenience.
 
 ## `/start` Endpoint
 
-Visiting `/start` triggers the article processing pipeline and displays three steps:
-
-1. Fetch articles.
-2. Run Hugging Face analysis on each article.
-3. Save predictions to `predictions_log.json`.
-
-The page returns an HTML report showing the results of each step.
+Visiting `/start` triggers the article processing pipeline and returns a JSON
+payload containing the model's structured predictions. Each entry includes the
+detected ticker, a trading action (`BUY`, `SELL` or `HOLD`), a confidence score
+and a short reason. Predictions are appended to `predictions_log.json` and the
+root page (`/`) renders them in a table.

--- a/api/routes.py
+++ b/api/routes.py
@@ -1,15 +1,25 @@
 from fastapi import APIRouter, HTTPException
 from model.hf_predict import analyze_news_article
+from model.stock_predict import extract_ticker, get_price_indicators, make_recommendation
 
 router = APIRouter()
 
 @router.post("/")
 async def predict_from_news(article: dict):
     try:
-        result = analyze_news_article(article["content"])
-        if "error" in result:
-            raise HTTPException(status_code=400, detail=result["error"])
-        return {"result": result}
+        sentiment = analyze_news_article(article["content"])
+        if "error" in sentiment:
+            raise HTTPException(status_code=400, detail=sentiment["error"])
+        text = article.get("title", "") + " " + article["content"]
+        ticker = extract_ticker(text)
+        indicators = get_price_indicators(ticker) if ticker else {}
+        recommendation = make_recommendation(sentiment, indicators)
+        return {
+            "ticker": ticker,
+            "action": recommendation["action"],
+            "confidence": recommendation["confidence"],
+            "reason": recommendation["reason"],
+        }
     except HTTPException:
         raise
     except Exception as e:


### PR DESCRIPTION
## Summary
- switch Hugging Face usage to a FinBERT text-classification pipeline that yields sentiment probabilities
- combine sentiment scores with price indicators for BUY/SELL/HOLD recommendations with confidence and reasoning
- expose structured `ticker`, `action`, `confidence`, and `reason` fields via `/start` and `/predict`, and show them in the HTML dashboard

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896b98dc72c83288c8686a0efa86181