### PR TITLE
Validate NewsArticle payload for prediction endpoint

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -1,16 +1,36 @@
 from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, validator
+
 from model.hf_predict import analyze_news_article
 from model.stock_predict import extract_ticker, get_price_indicators, make_recommendation
 
+
+class NewsArticle(BaseModel):
+    """Schema for incoming news articles."""
+
+    title: str
+    content: str | None = None
+
+    @validator("content", pre=True, always=True)
+    def validate_content(cls, value: str | None) -> str:  # pragma: no cover - simple validation
+        """Ensure that article content is present and non-empty."""
+        if value is None:
+            raise ValueError("Article content is required.")
+        if not str(value).strip():
+            raise ValueError("Article content cannot be empty.")
+        return value
+
+
 router = APIRouter()
 
+
 @router.post("/")
-async def predict_from_news(article: dict):
+async def predict_from_news(article: NewsArticle):
     try:
-        sentiment = analyze_news_article(article["content"])
+        sentiment = analyze_news_article(article.content)
         if "error" in sentiment:
             raise HTTPException(status_code=400, detail=sentiment["error"])
-        text = article.get("title", "") + " " + article["content"]
+        text = f"{article.title} {article.content}"
         ticker = extract_ticker(text)
         indicators = get_price_indicators(ticker) if ticker else {}
         recommendation = make_recommendation(sentiment, indicators)
@@ -22,5 +42,5 @@ async def predict_from_news(article: dict):
         }
     except HTTPException:
         raise
-    except Exception as e:
+    except Exception as e:  # pragma: no cover - defensive programming
         raise HTTPException(status_code=500, detail=str(e))

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,0 +1,73 @@
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def client(monkeypatch):
+    # Avoid importing heavy transformer and torch libraries during tests
+    import sys
+    import types
+    from pathlib import Path
+
+    dummy_transformers = types.SimpleNamespace(
+        pipeline=lambda *args, **kwargs: (lambda text: [])
+    )
+    monkeypatch.setitem(sys.modules, "transformers", dummy_transformers)
+
+    # Ensure project root on path for "import main"
+    project_root = Path(__file__).resolve().parents[1]
+    sys.path.append(str(project_root))
+
+    from main import app
+
+    return TestClient(app)
+
+
+def test_predict_success(client, monkeypatch):
+    def mock_analyze(text):
+        return {"scores": {"POSITIVE": 0.9, "NEGATIVE": 0.1}}
+
+    def mock_extract(text):
+        return "AAPL"
+
+    def mock_get_price_indicators(ticker):
+        return {"direction": "up", "prob_up": 0.8}
+
+    def mock_make_recommendation(sentiment, indicators):
+        return {"action": "BUY", "confidence": 0.95, "reason": "Test"}
+
+    monkeypatch.setattr("api.routes.analyze_news_article", mock_analyze)
+    monkeypatch.setattr("api.routes.extract_ticker", mock_extract)
+    monkeypatch.setattr("api.routes.get_price_indicators", mock_get_price_indicators)
+    monkeypatch.setattr("api.routes.make_recommendation", mock_make_recommendation)
+
+    response = client.post(
+        "/predict/",
+        json={"title": "Some title", "content": "Some informative content"},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "ticker": "AAPL",
+        "action": "BUY",
+        "confidence": 0.95,
+        "reason": "Test",
+    }
+
+
+def test_predict_missing_content(client):
+    response = client.post("/predict/", json={"title": "Missing content"})
+    assert response.status_code == 422
+    assert response.json()["detail"][0]["msg"].endswith(
+        "Article content is required."
+    )
+
+
+def test_predict_empty_content(client):
+    response = client.post(
+        "/predict/", json={"title": "Empty content", "content": ""}
+    )
+    assert response.status_code == 422
+    assert response.json()["detail"][0]["msg"].endswith(
+        "Article content cannot be empty."
+    )


### PR DESCRIPTION
## Summary
- introduce `NewsArticle` Pydantic model
- validate article content and use typed input in `/predict`
- add API tests for valid and invalid news articles

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896bc6841b4832881b3d96ab050e1ec